### PR TITLE
Show how to install prerequisite R package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can install the released version of CIBERSORT from [github](https://github.c
 
 ``` r
 install.packages("devtools")
+devtools::install_github("bmbolstad/preprocessCore")
 devtools::install_github("Moonerss/CIBERSORT")
 ```
 


### PR DESCRIPTION
Hi @Moonerss, 

I've added some documentation that was missing. The `preprocessCore` is not on CRAN, hence user need to install it first. Adding this to the doc will prevent other users searching for this too :+1:

Cheers, Richel Bilderbeek